### PR TITLE
Support alias login

### DIFF
--- a/src/aws-cpp-cognito-auth/Auth.cpp
+++ b/src/aws-cpp-cognito-auth/Auth.cpp
@@ -94,10 +94,11 @@ Aws::Auth::AWSCredentials CognitoAuth::Authenticate(
 	const Aws::String salt = challengeParameters["SALT"];
 	const Aws::String srpB = challengeParameters["SRP_B"];
 	const Aws::String secretBlock = challengeParameters["SECRET_BLOCK"];
+	const Aws::String userIdForSrp  = challengeParameters["USER_ID_FOR_SRP"];
 
 	auto claim = srp.GeneratePasswordClaim(
 		userPoolId,
-		username,
+		userIdForSrp,
 		password,
 		salt.c_str(),
 		srpB.c_str(),


### PR DESCRIPTION
In the email or phone number alias login, `InitiateAuth` is called with the alias as username,
but the following calls in the authentication flow must use the actual user id. The id is
returned in `InitiateAuth` response. Support for using it is added here.