### PR TITLE
Fix failing authentication when hash of 'AB' result was small

### DIFF
--- a/src/aws-cpp-cognito-auth/Srp.cpp
+++ b/src/aws-cpp-cognito-auth/Srp.cpp
@@ -87,11 +87,12 @@ void Srp::GenerateKey(
 {
 	Digest d;
 
-	std::vector<uint8_t> salt;
 	std::vector<uint8_t> ab;
 	Helpers::HexToBinary( ab, Helpers::PadLeftZero( m_A.get() ) + Helpers::PadLeftZero( sB ) );
-	d.Sha256( salt, ab );
-	salt = Helpers::PadLeftZero( salt );
+
+	std::vector<uint8_t> ab_digest;
+	d.Sha256( ab_digest, ab );
+	ab_digest = Helpers::PadLeftZero( ab_digest );
 
 	std::vector<uint8_t> idDigest;
 	d.Sha256( idDigest, id );
@@ -112,7 +113,7 @@ void Srp::GenerateKey(
 	BigNumber B;
 
 	x.fromBin( x_digest );
-	u.fromBin( salt );
+	u.fromBin( ab_digest );
 	B.fromHex( sB );
 
 	BigNumber g_mod_xn;
@@ -135,10 +136,16 @@ void Srp::GenerateKey(
 	b_sub_modpow.modExp( b_sub, a_add, m_N, context );
 	S.mod( b_sub_modpow, m_N, context );
 
-	BigNumberString sS;
-	S.toHex( sS );
+	BigNumberString u_str;
+	u.toHex(u_str);
+	std::vector<uint8_t> salt;
+	Helpers::HexToBinary( salt, u_str.get() );
+	salt = Helpers::PadLeftZero( salt );
+
+	BigNumberString S_str;
+	S.toHex( S_str );
 	std::vector<uint8_t> secret;
-	Helpers::HexToBinary( secret, sS.get() );
+	Helpers::HexToBinary( secret, S_str.get() );
 	secret = Helpers::PadLeftZero( secret );
 
 	const std::string labelS = "Caldera Derived Key";


### PR DESCRIPTION
During usage of this library, it was discovered that even for correct credentials, authentication failed randomly with failure rate somewhere between 1:100 and 1:1000. After careful testing and comparison with amazon-cognito-identity-js (which does not have the same problem), I discovered that the failure occurs if the _salt_ parameter of hkdf algorithm has too many leading zeroes. The leading zeroes appear if _SHA-256(AB)_ used to form _salt_ happens to a result containing them.

The problem is fixed here by converting the byte array result first into number _u_ (which was already used for other parts of the protocol), then back to byte array, similarly to how other inputs to hkdf are handled.

I verified that the solution works by running authentication 4000 times in a loop. Without fix, there were multiple errors, with the fix applied none.