### PR TITLE
Add new feature: Authenticate with user pool only and return tokens.

### DIFF
--- a/include/aws-cpp-cognito-auth/Auth.hpp
+++ b/include/aws-cpp-cognito-auth/Auth.hpp
@@ -35,6 +35,28 @@
 
 namespace awsx {
 
+	class CognitoTokens {
+	protected:
+		std::string m_accessToken;
+		std::string m_idToken;
+		std::string m_refreshToken;
+		int m_expiresIn;
+
+	public:
+		CognitoTokens(std::string& accessToken, std::string& idToken, std::string& refreshToken, int expiresIn)
+			: m_accessToken(accessToken)
+			, m_idToken(idToken)
+			, m_refreshToken(refreshToken)
+			, m_expiresIn(expiresIn)
+		{
+		}
+
+		std::string& GetAccessToken() { return m_accessToken; }
+		std::string& GetIdToken() { return m_idToken; }
+		std::string& GetRefreshToken() { return m_refreshToken; }
+		int GetExpiresIn() { return m_expiresIn; }
+	};
+
 	class CognitoAuth {
 	protected:
 		std::string m_clientId;
@@ -47,7 +69,13 @@ namespace awsx {
 			}
 		}
 
-	public:
+		CognitoTokens AuthenticateWithUserPoolInternal(
+			Aws::Client::ClientConfiguration& clientConfig,
+			const std::string& username,
+			const std::string& userPoolId,
+			const std::string& password);
+
+    public:
 		CognitoAuth( const std::string & regionId, const std::string & clientId )
 			: m_regionId( regionId )
 			, m_clientId( clientId )
@@ -59,6 +87,11 @@ namespace awsx {
 			const std::string & password,
 			const std::string & userPoolId,
 			const std::string & identityPoolId );
+
+		CognitoTokens AuthenticateWithUserPool(
+			const std::string& username,
+			const std::string& password,
+			const std::string& userPoolId);
 	};
 
 }

--- a/src/aws-cpp-cognito-auth-demo/aws-cpp-cognito-auth-demo.cpp
+++ b/src/aws-cpp-cognito-auth-demo/aws-cpp-cognito-auth-demo.cpp
@@ -24,6 +24,39 @@
 
 #include "stdafx.h"
 
+void authDemo(
+	const std::string& regionId,
+	const std::string& clientId,
+	const std::string& username,
+	const std::string& password,
+	const std::string& userPoolId,
+	const std::string& identityPoolId )
+{
+	awsx::CognitoAuth auth( regionId, clientId );
+	auto creds = auth.Authenticate( username, password, userPoolId, identityPoolId );
+
+	if (!creds.GetAWSAccessKeyId().empty()) {
+		std::cout << "access key = " << creds.GetAWSAccessKeyId() << std::endl;
+	}
+}
+
+void authDemoWithUserPool(
+	const std::string& regionId,
+	const std::string& clientId,
+	const std::string& username,
+	const std::string& password,
+	const std::string& userPoolId )
+{
+	awsx::CognitoAuth auth( regionId, clientId );
+	auto creds = auth.AuthenticateWithUserPool( username, password, userPoolId );
+
+	if (!creds.GetAccessToken().empty()) {
+		std::cout << "access token = " << creds.GetAccessToken() << std::endl;
+		std::cout << "id token = " << creds.GetIdToken() << std::endl;
+		std::cout << "refresh token = " << creds.GetRefreshToken() << std::endl;
+		std::cout << "expires in = " << creds.GetExpiresIn() << std::endl;
+	}
+}
 
 int main()
 {
@@ -38,12 +71,9 @@ int main()
 		std::string userPoolId = "";		// without region
 		std::string identityPoolId = "";	// without region
 
-		awsx::CognitoAuth auth( regionId, clientId );
-		auto creds = auth.Authenticate( username, password, userPoolId, identityPoolId );
-
-		if (!creds.GetAWSAccessKeyId().empty()) {
-			std::cout << "access key = " << creds.GetAWSAccessKeyId() << std::endl;
-		}
+		authDemo( regionId, clientId, username, password, userPoolId, identityPoolId );
+		// Alternate usage
+		//authDemoWithUserPool( regionId, clientId, username, password, userPoolId );
 	}
 	catch (const std::exception & x) {
 		std::cerr << x.what() << std::endl;


### PR DESCRIPTION
The original implementation only included a longer flow that proceeded to interact with an Identity Pool and returned aws access keys.